### PR TITLE
Add intelligence analyst research plan

### DIFF
--- a/Intelligence-Analyst/LinkedIn_Infiltration_Research_Plan.md
+++ b/Intelligence-Analyst/LinkedIn_Infiltration_Research_Plan.md
@@ -1,0 +1,28 @@
+# 10-Hour Research Plan for MSS LinkedIn Infiltration Investigation
+
+| Hour | Activities (What is to be done) | Expected Results (What is to be resulted) | Reports / Deliverables (What we expect) |
+|------|--------------------------------|-------------------------------------------|-----------------------------------------|
+| 1 | Review repository documentation and prior intelligence reports to establish context on MSS use of LinkedIn and AI. | Analyst understands investigative scope and tactics employed by MSS on professional platforms. | Brief orientation memo summarizing repository goals and relevant open-source background. |
+| 2 | Inventory all suspicious LinkedIn personas and associated artifacts in `LinkedIn/Sesame/`. | Consolidated list of 11 personas with available images, PDFs, and text artifacts. | Account inventory spreadsheet or table (name, data present, initial notes). |
+| 3 | Examine `AIDR_results_summary.txt` to log AI-flagged images and features for each persona. | Table of 49 flagged images with specific facial features noted for each account. | Annotated AIDR feature matrix for quick reference during manual review. |
+| 4 | Manually inspect images to validate AI detection: note artifacts, inconsistencies, or evidence of genuine photography. | Assessment of which flagged features appear credible, potentially false positives, or likely synthetic. | Image assessment worksheet with screenshots and notes. |
+| 5 | Map potential relationships among personas (shared employers, mutual contacts, common imagery). | Preliminary network diagram showing suspected linkages and possible clusters. | Network relationship chart (visual or tabular) with supporting observations. |
+| 6 | Cross-reference each persona with public records, breach data, or known professionals to check for identity theft. | Identified matches, mismatches, or unverifiable identities for each account. | Cross-reference log citing data sources and confidence ratings. |
+| 7 | Construct activity timelines for personas (account creation, posting cadence, outreach patterns). | Timeline highlighting synchronized behavior or anomalies suggestive of coordinated operation. | Timeline visualization or chronologically ordered table per persona. |
+| 8 | Compare observed tactics with MSS AI strategies from `Grok_MSS_AI_Development_Report.md` and `Ankaa_Intel_Report__08.20.25.txt`. | Analytical notes linking persona behaviors to known MSS AI-enabled methods. | Two-page analytic memo connecting repository findings to MSS AI objectives. |
+| 9 | Evaluate reliability of the AI detection approach (AIDR) and note gaps or improvements needed. | Methodological assessment of AIDR’s false positive/negative rates and feature limitations. | Short methodology review recommending refinement areas for image analysis. |
+| 10 | Synthesize all findings into a comprehensive briefing on MSS-linked LinkedIn infiltration, including defensive recommendations. | Cohesive narrative describing patterns of synthetic identities, potential targeting, and countermeasures. | Final investigative report with executive summary, appendices (network map, timeline, evidence tables), and recommendations slide deck. |
+
+## Key Repository References
+- Objectives emphasize cataloging suspicious accounts, performing synthetic-media analysis, mapping relationships, and correlating with public records
+- Investigation centers on MSS infiltration of LinkedIn using fake or stolen identities and AI-generated content
+- Current dataset includes 49 AI-flagged images across 11 personas, informing image-analysis tasks in this plan
+- Research goal to document patterns of synthetic or stolen identities underpins deliverables in the final report
+
+## Expected Reporting
+- **Orientation Memo** (Hour 1)
+- **Account Inventory** and **AIDR Feature Matrix** (Hours 2–3)
+- **Image Assessment Worksheet** and **Network Relationship Chart** (Hours 4–5)
+- **Cross-Reference Log** and **Timeline Visualizations** (Hours 6–7)
+- **Analytic Memo on MSS AI Tactics** and **Methodology Review** (Hours 8-9)
+- **Comprehensive Final Report & Slide Deck** synthesizing findings and recommendations (Hour 10)


### PR DESCRIPTION
## Summary
- add 10-hour research plan document for MSS LinkedIn infiltration investigation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8a1e2239c832db5080b3670b96e93