### PR TITLE
Document LinkedIn shell companies LIA and Vendisys

### DIFF
--- a/shell-companies/README.md
+++ b/shell-companies/README.md
@@ -1,0 +1,20 @@
+# Shell Companies Leveraging LinkedIn Automation
+
+LinkedIn has identified and removed shell companies that sold large-scale automation and fake profile services. Two notable examples are **LIA** and **Vendisys**, both of which promoted subscription packages around $300 per month and relied on AI-generated personas to infiltrate professional networks.
+
+## LIA
+
+LIA marketed clusters of fake LinkedIn profiles complete with AI-generated avatars, job histories, and connection scripts. For roughly $300 a month, clients received dozens of ready-to-use identities and message templates. LinkedIn has since removed LIA's company page and associated accounts for violating platform policies.
+
+## Vendisys
+
+Vendisys offered similar LinkedIn automation, selling $300 per month packages that delivered synthetic avatars and high-volume outreach tools. Following enforcement actions, LinkedIn took down Vendisys' pages and suspended related profiles.
+
+## Company Catalog
+
+| Company | Location | Offering | Status | Sources |
+| ------- | -------- | -------- | ------ | ------- |
+| LIA | Delhi, India | $300/month AI-generated LinkedIn avatars and fake profiles | Removed by LinkedIn | |
+| Vendisys | San Francisco, USA | $300/month LinkedIn automation and synthetic personas | Removed by LinkedIn | |
+|  |  |  |  |  |
+


### PR DESCRIPTION
## Summary
- create `shell-companies/` with README summarizing LIA and Vendisys shell companies and LinkedIn's removal actions
- add company catalog table with placeholder row for future entries

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8b7168590832d8541dbbeaa90a9d4