### PR TITLE
Add dataset scaffolding and update utility script

### DIFF
--- a/datasets/README.md
+++ b/datasets/README.md
@@ -1,0 +1,18 @@
+# Datasets
+
+This directory stores structured datasets used by the project.
+
+## Schema
+
+Both CSV and JSON datasets should use the following fields:
+
+- `profile_id`: Unique identifier for a profile or record.
+- `sector`: The sector or industry related to the entry.
+- `source`: Origin of the data (e.g., OSINT, report, internal).
+
+CSV files must include a header row with these columns. JSON files should contain an array of objects with these keys.
+
+## Files
+
+- `fake_profiles.csv`: placeholder for profile records.
+- `indictments.csv`: placeholder for legal indictment information.

--- a/datasets/fake_profiles.csv
+++ b/datasets/fake_profiles.csv
@@ -1,0 +1,1 @@
+profile_id,sector,source

--- a/datasets/indictments.csv
+++ b/datasets/indictments.csv
@@ -1,0 +1,1 @@
+profile_id,sector,source

--- a/scripts/update_datasets.py
+++ b/scripts/update_datasets.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Append new records to dataset CSV files.
+
+Example:
+    python scripts/update_datasets.py datasets/fake_profiles.csv P123 finance open_source
+"""
+
+import argparse
+import csv
+from pathlib import Path
+
+def append_record(file_path: str, profile_id: str, sector: str, source: str) -> None:
+    """Append a record to a dataset CSV file.
+
+    Parameters
+    ----------
+    file_path : str
+        Path to CSV file.
+    profile_id : str
+        Unique profile identifier.
+    sector : str
+        Sector classification.
+    source : str
+        Origin of the record.
+    """
+    fieldnames = ["profile_id", "sector", "source"]
+    file_exists = Path(file_path).exists()
+    with open(file_path, "a", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        if not file_exists or f.tell() == 0:
+            writer.writeheader()
+        writer.writerow({
+            "profile_id": profile_id,
+            "sector": sector,
+            "source": source,
+        })
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Append a record to a dataset CSV.")
+    parser.add_argument("file_path", help="Path to dataset CSV to update")
+    parser.add_argument("profile_id", help="Unique profile identifier")
+    parser.add_argument("sector", help="Sector classification")
+    parser.add_argument("source", help="Source of the record")
+    args = parser.parse_args()
+
+    append_record(args.file_path, args.profile_id, args.sector, args.source)
+    print(f"Appended record for {args.profile_id} to {args.file_path}")


### PR DESCRIPTION
## Summary
- document CSV/JSON schema for datasets
- add placeholder datasets and update script for appending records

## Testing
- `python scripts/update_datasets.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68a8b71ce938832d8540791d8371a466