### PR TITLE
Add source links for shell companies

### DIFF
--- a/shell-companies/README.md
+++ b/shell-companies/README.md
@@ -14,7 +14,6 @@ Vendisys offered similar LinkedIn automation, selling $300 per month packages th
 
 | Company | Location | Offering | Status | Sources |
 | ------- | -------- | -------- | ------ | ------- |
-| LIA | Delhi, India | $300/month AI-generated LinkedIn avatars and fake profiles | Removed by LinkedIn | |
-| Vendisys | San Francisco, USA | $300/month LinkedIn automation and synthetic personas | Removed by LinkedIn | |
-|  |  |  |  |  |
+| LIA | Delhi, India | $300/month AI-generated LinkedIn avatars and fake profiles | Removed by LinkedIn | [lia.co](https://lia.co) |
+| Vendisys | San Francisco, USA | $300/month LinkedIn automation and synthetic personas | Removed by LinkedIn | [vendisys.com](https://vendisys.com) |
 


### PR DESCRIPTION
## Summary
- link LIA and Vendisys entries to their official sites
- remove trailing empty row in shell-companies table

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8c8df32d4832da1d1db80c83002a4