### PR TITLE
Validate dataset updates and prevent duplicate profile IDs

### DIFF
--- a/tests/test_update_datasets.py
+++ b/tests/test_update_datasets.py
@@ -1,0 +1,36 @@
+import csv
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.update_datasets import append_record
+
+
+def test_append_record_success(tmp_path):
+    csv_file = tmp_path / "data.csv"
+    append_record(csv_file, "P123", "finance", "osint")
+    append_record(csv_file, "P124", "technology", "report")
+
+    with open(csv_file, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+
+    assert rows == [
+        {"profile_id": "P123", "sector": "finance", "source": "osint"},
+        {"profile_id": "P124", "sector": "technology", "source": "report"},
+    ]
+
+
+def test_append_record_duplicate_profile_id(tmp_path):
+    csv_file = tmp_path / "data.csv"
+    append_record(csv_file, "P123", "finance", "osint")
+    with pytest.raises(ValueError):
+        append_record(csv_file, "P123", "finance", "report")
+
+    with open(csv_file, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+
+    assert rows == [
+        {"profile_id": "P123", "sector": "finance", "source": "osint"}
+    ]


### PR DESCRIPTION
## Summary
- enforce non-empty fields and approved sectors when appending to dataset CSVs
- reject attempts to append records with existing profile IDs
- add tests covering successful appends and duplicate prevention

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8c8e0b824832da84603b1e5d4a741