### PR TITLE
Add 100-hour Sesame intelligence research schedule

### DIFF
--- a/Intelligence-Analyst/100-HOUR-SCOPE-PROPOSAL.md
+++ b/Intelligence-Analyst/100-HOUR-SCOPE-PROPOSAL.md
@@ -1,0 +1,267 @@
+# 100-Hour Intelligence Analyst Research Schedule: Sesame Company Analysis
+
+**Research Target**: Sesame Company - AI-Generated Profiles and Chinese-English Translation Patterns Investigation  
+**Total Duration**: 100 Hours (4 weeks @ 25 hours per week)  
+**Classification**: UNCLASSIFIED//FOR OFFICIAL USE ONLY
+
+---
+
+## Phase I: Intelligence Preparation & Foundation (Hours 1-15)
+
+### Week 1, Days 1-2: Initial Intelligence Gathering
+
+**Hour 1-3: Target Identification & Source Mapping**
+- Create comprehensive target folder for "Sesame" company
+- Map potential connections to LinkedIn infiltration repository
+- Establish OSINT source priority matrix
+- Document initial hypothesis regarding MSS connection
+- Set up secure research environment and documentation protocols
+
+**Hour 4-6: LinkedIn Profile Collection**
+- Systematically harvest LinkedIn profiles associated with "Sesame"
+- Screenshot and archive all profiles for forensic analysis
+- Create database of employee names, positions, and profile creation dates
+- Note profile photo characteristics and biographical inconsistencies
+- Cross-reference against known MSS operational patterns
+
+**Hour 7-9: Company Registration & Corporate Intelligence**
+- Research Sesame's business registration records across jurisdictions
+- Analyze corporate structure, ownership, and financial filings
+- Map subsidiary companies and international operations
+- Investigate board members and key personnel backgrounds
+- Document any shell company indicators or suspicious corporate structures
+
+**Hour 10-12: Digital Footprint Analysis**
+- Analyze company website architecture and hosting information
+- Examine domain registration history and SSL certificate patterns
+- Map social media presence across multiple platforms
+- Document content publishing patterns and linguistic anomalies
+- Create timeline of digital presence establishment
+
+**Hour 13-15: Initial Pattern Recognition**
+- Compile preliminary findings into analytical framework
+- Identify initial red flags suggesting AI-generated content
+- Document potential Chinese language transfer patterns
+- Establish working hypotheses for deeper investigation
+- Brief preparation for specialized linguistic analysis
+
+---
+
+## Phase II: Linguistic Analysis & AI Detection (Hours 16-40)
+
+### Week 1, Days 3-5: Chinese-English Translation Pattern Analysis
+
+**Hour 16-20: Baseline Chinese-English Error Pattern Research**
+- Study documented Chinese L1 transfer errors in English
+- Catalog common grammatical transfer patterns from Mandarin
+- Research preposition errors, verb tense issues, and article usage
+- Document culturally inappropriate idiom translations
+- Create reference database of typical Chinese-English mistakes
+
+**Hour 21-25: Sesame Content Linguistic Forensics**
+- Analyze all Sesame-associated English text for L1 transfer patterns
+- Identify grammatical structures suggesting Chinese origin
+- Document vocabulary choices indicating non-native English
+- Analyze sentence construction patterns and discourse markers
+- Flag culturally inappropriate expressions or direct translations
+
+**Hour 26-30: Idiom & Cultural Reference Analysis**
+- Catalog any Chinese idioms directly translated into English
+- Identify culturally inappropriate business expressions
+- Analyze metaphorical language usage patterns
+- Document numerical references with Chinese cultural significance
+- Research honorific usage and hierarchical language patterns
+
+**Hour 31-35: Temporal & Linguistic Consistency Analysis**
+- Map language proficiency evolution across time periods
+- Identify sudden improvements in English fluency
+- Document inconsistencies in writing style between authors
+- Analyze email/message timestamp patterns for geographic indicators
+- Cross-reference linguistic patterns with profile creation dates
+
+**Hour 36-40: AI-Generated Text Detection**
+- Apply statistical analysis for machine-generated content
+- Test content against AI detection algorithms
+- Analyze vocabulary diversity and perplexity scores
+- Examine repetitive phrase patterns and unnatural constructions
+- Document findings indicating synthetic text generation
+
+---
+
+## Phase III: Deep Forensic Investigation (Hours 41-70)
+
+### Week 2-3: Advanced Technical Analysis
+
+**Hour 41-45: Image Forensics & Deepfake Detection**
+- Analyze all profile photos using deepfake detection tools
+- Examine metadata for generation signatures
+- Test images against StyleGAN detection algorithms
+- Document facial feature averaging patterns
+- Create forensic image analysis report
+
+**Hour 46-50: Network Analysis & Connection Mapping**
+- Map LinkedIn connection networks for Sesame employees
+- Identify clustering patterns suggesting coordinated activity
+- Analyze connection timing and mutual connections
+- Document any connections to known MSS-linked profiles
+- Create social network analysis visualization
+
+**Hour 51-55: Communications Pattern Analysis**
+- Analyze messaging patterns and response timing
+- Document recruitment approach methodologies
+- Map target selection criteria and outreach strategies
+- Identify systematic approaches to relationship building
+- Correlate with known MSS operational patterns
+
+**Hour 56-60: Technical Infrastructure Investigation**
+- Trace IP addresses and hosting infrastructure
+- Analyze email server configurations and security certificates
+- Investigate VPN usage patterns and geographic masking
+- Document technical security measures and operational security
+- Map infrastructure connections to Chinese entities
+
+**Hour 61-65: Financial & Economic Intelligence**
+- Investigate financial flows and payment methods
+- Analyze business model sustainability and revenue sources
+- Research funding sources and investment patterns
+- Document any Chinese government or SOE connections
+- Assess economic intelligence collection capabilities
+
+**Hour 66-70: Cross-Platform Correlation Analysis**
+- Compare Sesame presence across multiple social platforms
+- Analyze content consistency and messaging alignment
+- Document platform-specific adaptation strategies
+- Identify cross-platform operational security failures
+- Map broader digital influence operations
+
+---
+
+## Phase IV: Advanced Linguistic & Cultural Analysis (Hours 71-85)
+
+### Week 3-4: Specialized Chinese Language Analysis
+
+**Hour 71-75: Chinese Cultural Context Identification**
+- Identify Chinese cultural assumptions in English communications
+- Document Confucian hierarchical language patterns
+- Analyze face-saving communication strategies
+- Identify guanxi relationship-building approaches
+- Research Chinese business etiquette reflected in English
+
+**Hour 76-80: Machine Translation Artifact Detection**
+- Identify systematic translation software usage patterns
+- Analyze unnatural phrase constructions suggesting MT
+- Document character-by-character translation errors
+- Research specific translation software signatures
+- Test sample text against known MT engines
+
+**Hour 81-85: Advanced Discourse Analysis**
+- Examine discourse patterns reflecting Chinese communication styles
+- Analyze topic introduction and conversation flow patterns
+- Document cultural assumptions about professional relationships
+- Identify Chinese rhetorical strategies in English communication
+- Research propaganda discourse patterns in business communications
+
+---
+
+## Phase V: Intelligence Synthesis & Assessment (Hours 86-100)
+
+### Week 4: Final Analysis & Reporting
+
+**Hour 86-90: Evidence Correlation & Validation**
+- Cross-validate findings across multiple analytical approaches
+- Assess confidence levels for each identified pattern
+- Document chain of evidence for key findings
+- Identify gaps requiring additional collection
+- Prepare preliminary conclusions
+
+**Hour 91-95: Threat Assessment & Strategic Implications**
+- Assess Sesame's role in broader MSS operations
+- Evaluate intelligence collection capabilities
+- Analyze potential targets and operational objectives
+- Document counterintelligence implications
+- Assess threat to US persons and entities
+
+**Hour 96-100: Final Report Preparation**
+- Draft comprehensive intelligence assessment
+- Create executive summary with key findings
+- Develop recommendations for further investigation
+- Prepare briefing materials for stakeholders
+- Document lessons learned and analytical improvements
+
+---
+
+## Daily Research Protocols
+
+### Standard Operating Procedures
+
+**Security Protocols**:
+- Use VPN and secure browser configurations
+- Document all sources with proper attribution
+- Maintain air-gapped analysis environment
+- Regular data backup to secure systems
+- OPSEC review of all research activities
+
+**Quality Control Measures**:
+- Peer review of linguistic analysis findings
+- Cross-validation of technical analysis results
+- Source credibility assessment protocols
+- Bias recognition and mitigation procedures
+- Analytical uncertainty documentation
+
+**Documentation Standards**:
+- Time-stamped research logs
+- Source evaluation and credibility ratings
+- Chain of custody for digital evidence
+- Analytical confidence assessments
+- Regular progress reporting to supervisors
+
+---
+
+## Specialized Tools & Resources
+
+### Linguistic Analysis Tools
+- Jieba Chinese word segmentation software
+- NLTK for natural language processing
+- Chinese-English parallel corpus databases
+- AI text detection algorithms (GPT-2 Detector, GLTR)
+- Statistical analysis software for pattern recognition
+
+### Technical Investigation Tools
+- OSINT frameworks (Maltego, SpiderFoot)
+- Image forensics suites (FotoForensics, Ghiro)
+- Network analysis tools (Gephi, NetworkX)
+- Deepfake detection algorithms
+- Reverse image search capabilities
+
+### Cultural & Language References
+- Chinese idiom databases and translation resources
+- Cultural context references for Chinese business practices
+- Academic papers on Chinese-English language transfer
+- MSS operational pattern databases
+- Comparative analysis of translation software outputs
+
+---
+
+## Expected Deliverables
+
+1. **Comprehensive Intelligence Assessment** (25-30 pages)
+2. **Technical Forensics Report** with evidence annexes
+3. **Linguistic Analysis Report** documenting Chinese transfer patterns
+4. **Network Analysis Visualization** of connections and relationships
+5. **Recommendations for Counterintelligence Actions**
+6. **Lessons Learned Document** for future investigations
+
+---
+
+## Risk Mitigation
+
+**Operational Security**: All research conducted through secure channels with appropriate cover stories for any direct contact.
+
+**Legal Compliance**: Research limited to publicly available information with no unauthorized access attempts.
+
+**Source Protection**: Careful handling of any human sources with appropriate security protocols.
+
+**Analytical Objectivity**: Regular bias checks and alternative hypothesis consideration throughout investigation.
+
+This schedule provides systematic coverage of all aspects necessary to determine Sesame's potential connection to MSS operations while maintaining professional intelligence standards and analytical rigor.
+


### PR DESCRIPTION
## Summary
- add comprehensive 100-hour research schedule for Sesame Company in Intelligence-Analyst folder

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa2a4f2e24832db3ceb6aed9efeb61