### PR TITLE
Document suspected identity-theft personas

### DIFF
--- a/LinkedIn/Sesame/Identity-Theft-Suspected/Brendan-Iribe/README.md
+++ b/LinkedIn/Sesame/Identity-Theft-Suspected/Brendan-Iribe/README.md
@@ -1,3 +1,3 @@
 # Brendan Iribe – Suspected Identity Theft
 
-This folder holds Google search results, Google profile screenshots and Instagram posts linked to Brendan Iribe. The LinkedIn persona under review appears to reuse these public images, suggesting the account may impersonate the Oculus co-founder. Embedded text in the screenshots can be extracted via OCR for deeper investigation.
+This folder holds Google search results, Google profile screenshots and Instagram posts linked to Brendan Iribe. Several images show Iribe with fellow Oculus co-founder Nate Mitchell, reinforcing their association. The LinkedIn persona under review appears to reuse these public images, suggesting the account may impersonate the Oculus co-founder. Open-source queries also pair Iribe’s name with Sesame, albeit loosely. Embedded text in the screenshots can be extracted via OCR for deeper investigation.

--- a/LinkedIn/Sesame/Identity-Theft-Suspected/Gordon-Wetzstein/README.md
+++ b/LinkedIn/Sesame/Identity-Theft-Suspected/Gordon-Wetzstein/README.md
@@ -1,3 +1,3 @@
 # Gordon Wetzstein – Suspected Identity Theft
 
-Contains a single photo (`IMG_7370.png`) believed to show the real Gordon Wetzstein. The LinkedIn profile in question likely reuses this image without authorization, indicating a stolen identity scenario. Any text embedded in the image can be extracted with OCR tools.
+Contains a single photo (`IMG_7370.png`) believed to show the real Gordon Wetzstein. The LinkedIn profile in question likely reuses this image without authorization, indicating a stolen identity scenario. Wetzstein co-founded Zinn Labs, reportedly acquired by Sesame, and is currently unreachable—possibly on sabbatical in a remote area until April 2026. Any text embedded in the image can be extracted with OCR tools.

--- a/LinkedIn/Sesame/Identity-Theft-Suspected/Nate-Mitchell/README.md
+++ b/LinkedIn/Sesame/Identity-Theft-Suspected/Nate-Mitchell/README.md
@@ -1,3 +1,3 @@
 # Nate Mitchell – Suspected Identity Theft
 
-Screenshots here capture Google and Reddit search results, a Forbes reference, a private Instagram page and an X profile for the real Nate Mitchell. The LinkedIn account examined may be exploiting these images, pointing to possible identity theft. OCR on these screenshots can surface additional metadata.
+Screenshots here capture Google and Reddit search results, a Forbes reference, a private Instagram page and an X profile for the real Nate Mitchell. They also show ties to fellow Oculus co-founder Brendan Iribe. The LinkedIn account examined may be exploiting these images, pointing to possible identity theft and loosely linking Mitchell with Sesame. OCR on these screenshots can surface additional metadata.

--- a/LinkedIn/Sesame/Identity-Theft-Suspected/README.md
+++ b/LinkedIn/Sesame/Identity-Theft-Suspected/README.md
@@ -1,3 +1,10 @@
 # Identity-Theft-Suspected LinkedIn Profiles
 
 Evidence in this directory indicates that certain LinkedIn accounts may reuse photographs of real individuals without consent. Subfolders document each potential victim and include screenshots of search results, social media pages, or other public sources. Many images carry OCR-extractable text for further analysis.
+
+## Suspected personas
+- **Brendan Iribe** – Google search results, profile screenshots, and Instagram posts appear reused by a LinkedIn persona impersonating the Oculus co-founder and associating him with Nate Mitchell.
+- **Gordon Wetzstein** – A Stanford professor whose photo is lifted for a LinkedIn profile; he co-founded Zinn Labs, reportedly acquired by Sesame, and is believed to be on sabbatical until April 2026.
+- **Nate Mitchell** – Search results, a Forbes mention, and social media profiles mirror a LinkedIn account that may exploit his images while loosely linking him with Sesame.
+
+All three names surface in open-source searches alongside Sesame, supporting the identity-theft suspicion.

--- a/LinkedIn/Sesame/README.md
+++ b/LinkedIn/Sesame/README.md
@@ -5,5 +5,5 @@ This folder consolidates evidence on LinkedIn accounts linked to the company "Se
 ## Key Items
 - `LinkedIn_HelpAssistant_Chat.pdf` and `LinkedIn_HelpAssistant_Chat_1.png`–`LinkedIn_HelpAssistant_Chat_7.png` – screenshots of a support conversation documenting attempts to flag the accounts.
 - `Fabrication-Suspected/` – profiles believed to be AI-generated, with image-analysis artifacts.
-- `Identity-Theft-Suspected/` – personas that appear to reuse real individuals' images without consent.
+- `Identity-Theft-Suspected/` – personas (e.g., Brendan Iribe, Gordon Wetzstein, Nate Mitchell) that appear to reuse real individuals' images without consent.
 - `Zinn-Labs (acquisition)/` – open-source material on Sesame's reported acquisition of Zinn Labs.


### PR DESCRIPTION
## Summary
- document suspected identity-theft personas and their links to Sesame
- note associations between Brendan Iribe, Nate Mitchell, and Gordon Wetzstein
- reference Zinn Labs acquisition and Wetzstein's unavailability until April 2026

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa153b9358832d8300928eb350b36e