### PR TITLE
Add event-based gaze risk summaries for Sesame and Zinn Labs

### DIFF
--- a/LinkedIn/Sesame/README.md
+++ b/LinkedIn/Sesame/README.md
@@ -7,3 +7,4 @@ This folder consolidates evidence on LinkedIn accounts linked to the company "Se
 - `Fabrication-Suspected/` – profiles believed to be AI-generated, with image-analysis artifacts.
 - `Identity-Theft-Suspected/` – personas (e.g., Brendan Iribe, Gordon Wetzstein, Nate Mitchell) that appear to reuse real individuals' images without consent.
 - `Zinn-Labs (acquisition)/` – open-source material on Sesame's reported acquisition of Zinn Labs.
+- `event-based-gaze-risk-report.md` – summary of event-based gaze tracking threats and mitigations.

--- a/LinkedIn/Sesame/Zinn-Labs (acquisition)/README.md
+++ b/LinkedIn/Sesame/Zinn-Labs (acquisition)/README.md
@@ -6,3 +6,4 @@ This directory gathers open-source material about Sesame's reported acquisition 
 - `Zinn-Labs_profile_full.png` – full LinkedIn profile screenshot.
 - `Zinn-Labs_Google_profile.png` and related images – search results and articles connecting Zinn Labs to Prophesee and Chinese partnerships.
 - `Zinn-Labs_Website.png` – capture of the corporate site prior to acquisition.
+- `event-based-gaze-risk-report.md` – summary of event-based gaze tracking risks and mitigations.

--- a/LinkedIn/Sesame/Zinn-Labs (acquisition)/event-based-gaze-risk-report.md
+++ b/LinkedIn/Sesame/Zinn-Labs (acquisition)/event-based-gaze-risk-report.md
@@ -1,0 +1,23 @@
+# Zinn Labs – Event-Based Gaze Tracking Risks
+
+## What's Real
+- **Prophesee integration:** Zinn Labs publicly used Prophesee's GenX320 event sensor (~3×4 mm, μW power modes) in its gaze stack for smart eyewear.
+- **Biometric potential:** Studies show eye-movement dynamics can re-identify individuals with up to ~95–100% accuracy within sessions and ~64–78% across sessions.
+- **Inference attacks:** "GAZEploit" demonstrated PIN/text inference on Apple Vision Pro via eye cues, illustrating risks once gaze data leaves the device.
+- **Corporate linkage:** Zinn Labs announced it "joined" Sesame AI in 2025, bringing its low-power gaze technology under Sesame's AI-glasses program.
+
+## Threat Model Highlights
+- Event-based sensors enable **silent, persistent capture** with low bandwidth and power.
+- Gaze signals fused with audio/video context can yield **identity persistence**, **secret inference** and **attention/affect estimates**.
+
+## Dual-Use Concerns
+- Covert surveillance and bystander capture via inconspicuous glasses.
+- Persistent gaze IDs feeding social-scoring or predictive-policing systems.
+- Data subject to PRC jurisdiction could be compelled under NIL, DSL or PIPL.
+
+## Mitigation Notes
+- Keep raw eye events on-device and expose only quantized intent signals.
+- Apply privacy filters that block keypad fixations and cap temporal resolution.
+- Attach C2PA provenance and watermarks to any exported summaries.
+- Align with EU AI Act bans on emotion inference and conduct NIST AI RMF audits.
+

--- a/LinkedIn/Sesame/event-based-gaze-risk-report.md
+++ b/LinkedIn/Sesame/event-based-gaze-risk-report.md
@@ -1,0 +1,23 @@
+# Event-Based Gaze Tracking – Risks and Controls
+
+## What's Real
+- **Low-power event cameras:** Dynamic Vision Sensors such as Prophesee's GenX320 enable microsecond-latency eye tracking at milliwatt to microwatt power budgets, allowing "always-on" smart glasses.
+- **Gaze as biometric:** Peer-reviewed studies report up to ~95–100% identification within a session and ~64–78% across sessions using eye-movement dynamics.
+- **Inference attacks:** Demonstrations like 2024's "GAZEploit" on Apple Vision Pro inferred typed text from eye cues, highlighting privacy risks.
+- **Corporate link:** Public records list Gordon Wetzstein as Zinn Labs co-founder; Zinn Labs announced it "joined" Sesame AI in 2025.
+
+## Threat Model (HLSF + Event-Based Gaze)
+- **Collection → Fusion → Inference → Action loop** using eye events, pupil metrics, blinks, ambient audio and device context.
+- **Inferences:** biometric re-identification, gaze-to-UI mapping for secrets (e.g., PINs), and affect/attention estimates.
+- **Actions:** personalization, surveillance, manipulation and targeting at scale.
+
+## Dual-Use Pivots
+- **Covert surveillance:** Small, low-power glasses can silently capture gaze and ambient data, risking bystander privacy.
+- **Tracking & scoring:** Persistent gaze-based IDs could feed social-scoring or predictive-policing systems.
+- **Cross-border leverage:** PRC laws (NIL, DSL, PIPL) enable state access to biometric/behavioral data.
+
+## Mitigation Strategies
+- **Technical safeguards:** on-device processing, rate-limited/obfuscated APIs, privacy filters that suppress keypad fixations, and provenance via C2PA manifests with watermarking.
+- **Policy & compliance:** align with EU AI Act prohibitions on emotion inference, perform export-control and human-rights due diligence, and audit against NIST AI RMF.
+- **User empowerment:** granular gaze/voice/environment toggles, sensitive-scene shielding (auto blur/muffle) and signed transparency exports.
+


### PR DESCRIPTION
## Summary
- document event-based eye-tracking risks and mitigations in Sesame directory
- add Zinn Labs–specific gaze risk report under acquisition materials

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab306379cc832db4b0ba1de94f9d5b