### PR TITLE
docs: link dataset scripts and tests

### DIFF
--- a/datasets/README.md
+++ b/datasets/README.md
@@ -12,8 +12,9 @@ All CSV and JSON datasets use the following fields:
 CSV files require a header row; JSON files should be arrays of objects with these keys.
 
 ## Maintaining Data
-- Append records with `python scripts/update_datasets.py <file> <profile_id> <sector> <source>`.
-- Generate summary statistics via `python scripts/analyze_datasets.py` which updates `analysis_summary.md`.
+- Append records with `python` [`update_datasets.py`](../scripts/update_datasets.py) `<file> <profile_id> <sector> <source>`.
+- Generate summary statistics via `python` [`analyze_datasets.py`](../scripts/analyze_datasets.py), which updates `analysis_summary.md`.
+- Validation tests for these scripts live under [`../tests/`](../tests/).
 
 ## Current Files
 - `fake_profiles.csv` – suspected synthetic or compromised LinkedIn profiles.


### PR DESCRIPTION
## Summary
- add links to dataset update and analysis scripts
- note validation tests under `tests/`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab38372960832d8d9c8439f23e379c