### PR TITLE
docs: add LinkedIn research plan and case studies

### DIFF
--- a/LinkedIn/README.md
+++ b/LinkedIn/README.md
@@ -2,11 +2,18 @@
 
 Evidence and reports related to LinkedIn personas suspected of MSS involvement.
 
+For guidance on ongoing analytic tasks, see the [LinkedIn Infiltration Research Plan](../Intelligence-Analyst/LinkedIn_Infiltration_Research_Plan.md).
+
 ## Structure
 - `Ankaa_Intel_Report__08.20.25.md` – background on MSS adoption of AI.
 - `Sesame/` – artifacts for the "Sesame" persona cluster, including suspected identity theft, fabrication cases, and analyses of export controls and voice cloning.
 
 New persona clusters should be added as subdirectories containing raw exports, screenshots, and analytic notes. Include a README in each folder summarizing key findings and source links.
+
+## Case Studies
+- [Kevin Mallory](../case-studies/kevin-mallory/README.md) – contacted by a Chinese agent via LinkedIn and later convicted under the Espionage Act.
+- [Yanjun Xu](../case-studies/yanjun-xu/README.md) – leveraged talent-recruitment programs and front companies to solicit aviation experts.
+- [Chen Lai](../case-studies/chen-lai/notes.md) – ongoing research into recruitment methods and operational timeline.
 
 ## Future Work
 - Map relationships between clusters and underlying infrastructure.


### PR DESCRIPTION
## Summary
- link LinkedIn README to the LinkedIn Infiltration Research Plan
- reference Kevin Mallory, Yanjun Xu, and Chen Lai case studies for contextual examples

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab383cc254832da34b3e7b83ca0c5d