### PR TITLE
test: add validation tests for append_record

### DIFF
--- a/tests/test_update_datasets.py
+++ b/tests/test_update_datasets.py
@@ -34,3 +34,23 @@ def test_append_record_duplicate_profile_id(tmp_path):
     assert rows == [
         {"profile_id": "P123", "sector": "finance", "source": "osint"}
     ]
+
+
+def test_append_record_invalid_sector(tmp_path):
+    csv_file = tmp_path / "data.csv"
+    with pytest.raises(ValueError):
+        append_record(csv_file, "P123", "invalid", "osint")
+
+
+@pytest.mark.parametrize(
+    "profile_id, sector, source",
+    [
+        ("", "finance", "osint"),
+        ("P123", "", "osint"),
+        ("P123", "finance", ""),
+    ],
+)
+def test_append_record_empty_fields(tmp_path, profile_id, sector, source):
+    csv_file = tmp_path / "data.csv"
+    with pytest.raises(ValueError):
+        append_record(csv_file, profile_id, sector, source)


### PR DESCRIPTION
## Summary
- add test for invalid sector names
- ensure empty fields trigger ValueError

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab38546e0c832da5f8feba11871547