### PR TITLE
Expand China human monitoring report

### DIFF
--- a/research/china_human_monitoring_report.md
+++ b/research/china_human_monitoring_report.md
@@ -1,26 +1,198 @@
-# China Human Monitoring Report
+# China: manpower engaged in human monitoring
 
-## Manpower
-- China's domestic political surveillance still depends heavily on human personnel from the Ministry of State Security and the Ministry of Public Security, with grid-style neighborhood monitors supplementing digital tools.[1]
-- Academic assessments estimate hundreds of thousands of community-level "stability maintenance" officers are tasked with reporting dissent and monitoring local activity.[2]
+A. Dedicated political‑security professionals (core “political police”)
 
-## Budget Estimates
-- Public budget data indicates that China's domestic security expenditures reached roughly 1.4 trillion yuan (about USD $200 billion) in 2023, surpassing official military spending.[3]
-- Provincial governments allocate additional funds for neighborhood committees and security contractors, making precise national totals difficult to verify.[4]
+MSS (Ministry of State Security) – size is secret; credible public estimates run from the low hundreds of thousands up to ~600,000 employees. (Example: former U.S. official James Lewis told 60 Minutes “as many as 600,000.”) 
+China News
 
-## Technology vs. Manpower
-- Despite large investments in cameras, facial recognition, and big-data analytics, experts note that technology augments but does not replace the need for human surveillance teams.[1]
-- AI-enabled systems often flag individuals for further investigation, but human officers still conduct interviews, site visits, and evidence collection.[5]
+MPS Domestic Security Department (国保/DSD) – the MPS’ political‑security arm is present down to municipal level; numbers are not public but the unit’s function and priority are well documented. For estimation below I treat DSD as a share of MPS sworn police (see B). 
+Leiden Asia Centre
 
-## Cross-Country Comparisons
-- China's estimated per-capita spending on internal security significantly exceeds that of liberal democracies such as the United States and Germany, where legal constraints limit the scale of domestic monitoring.[3][6]
-- Russia and Iran rely on similar human-led security architectures, though their budgets remain far smaller than China's, limiting nationwide coverage.[7]
+B. Police & auxiliaries who do political monitoring as part of “stability maintenance” (维稳)
 
----
-1. PRC Leader, "Political Surveillance Still Depends on Manpower," 2023, https://prcleader.org.
-2. Human Rights Watch, "China's Algorithms of Repression," 2021, https://www.hrw.org.
-3. MERICS, "China's Domestic Security Spending 2023," 2024, https://merics.org.
-4. Wall Street Journal, "China's 'Stability Maintenance' Costs Soar," 2022, https://www.wsj.com.
-5. Brookings Institution, "AI Surveillance in China: Augmentation, Not Replacement," 2022, https://www.brookings.edu.
-6. Center for Strategic and International Studies, "Comparative Surveillance Budgets," 2023, https://www.csis.org.
-7. Carnegie Endowment, "Authoritarian Surveillance: Russia and Iran," 2022, https://carnegieendowment.org.
+Sworn police (MPS) – China does not publish a current national figure; historical and expert references place it ~2 million today (1.43 million in 2003; commonly cited ~2 million now). 
+观察者网
+China Change
+
+Rationale: 2003 MPS data showed 1.43m police; since then both population and police density rose, and academic work on Chinese policing uses ~2m as an order‑of‑magnitude anchor. 
+观察者网
+Leiden Asia Centre
+
+Auxiliary police (辅警) – para‑police on local payrolls. ≥1.2 million nationwide by end‑2024 (MPS data, reported); several provinces cap auxiliaries at or below the number of sworn police, with some local ratios up to 1.5 auxiliaries per officer. 
+chinascope.org
+jxrd.jxnews.com.cn
+chinapeace.gov.cn
+
+C. Full‑time neighborhood “grid” managers (网格员)
+
+Grid workers – ~4.5 million nationwide, per the PRC Ministry of Justice (official). They staff 583,000 “comprehensive governance centers” and act as eyes/ears for local Political‑Legal Committees. 
+moj.gov.cn
+
+Bringing it together (headcount ranges)
+
+“Dedicated political‑security” (MSS + DSD): very uncertain; a defensible working range = 300k–900k (MSS 100k–600k + a fraction of MPS assigned to DSD tasks). 
+China News
+Leiden Asia Centre
+
+Police & auxiliaries (part‑time political monitoring): ~3.2m (≈2.0m sworn + ≥1.2m auxiliaries), of whom only a share of time is political/security monitoring. 
+chinascope.org
+China Change
+
+Neighborhood grid managers (full‑time monitoring): ~4.5m. 
+moj.gov.cn
+
+Order‑of‑magnitude takeaway: If you count the people whose primary job is feeding, doing, or coordinating political/domestic surveillance (MSS + DSD + grid), you get ~5–9 million people (broad band because MSS and DSD headcounts are opaque). If you also include sworn/auxiliary police time spent on 维稳 duties, the labor actually applied to human monitoring on any given day plausibly sits well above 6 million FTEs (grid + dedicated units + a slice of police/aux time).
+Anchor datapoint: The official 4.5 million grid workers alone make this an unusually manpower‑intensive system by global standards. 
+moj.gov.cn
+
+China: what does this cost (wage bill and budget anchors)?
+
+Because the central budget no longer itemizes all “domestic security” sub‑lines, I estimate a floor wage bill from units where wages are observable, and check it against top‑down “public security” budget aggregates.
+
+1) Bottom‑up “floor” wage bill (direct human monitoring)
+
+Grid workers (~4.5m). Public postings show monthly base pay typically ¥2,200–¥3,700 (examples from Hubei, Beijing Shunyi, Jinan). Annual wage bill ≈ ¥135–¥189 billion. 
+China Change
+
+Auxiliary police (≥1.2m, often 3,300–5,000 RMB/month; higher in some cities).
+Examples: ¥3,300–¥5,000 in Guangdong/Jiangsu/Tianjin postings; Beijing positions approach ¥80k–97k/yr packages. Annual wage bill = ¥48–¥120+ billion at 1.2m auxiliaries (larger if closer to 2m). 
+Sohu
++1
+blog.sina.com.cn
+
+MSS + MPS/DSD cadre. No open wage data; as an illustrative bracket, if 300k–900k personnel average ¥120k–¥180k/yr, that’s ¥36–¥162 billion in salaries. (This is a scenario calculation, not an official figure.) 
+Leiden Asia Centre
+China News
+
+→ Conservative “floor” for wages directly tied to human monitoring labor:
+~¥230–¥470 billion per year (grid + auxiliaries + plausible band for MSS/DSD), before employer social contributions, housing funds, training, overhead, and equipment.
+
+2) Top‑down cross‑check (domestic security budgets)
+
+PRC “public security” (domestic) spending across all levels reached ¥702bn (2012) and ¥769bn (2013), and by 2016 exceeded ¥1 trillion, outpacing defense that year. Later budgets became harder to disaggregate publicly, but the level remaining ≥¥1T from the mid‑2010s is well documented. 
+Reuters
+Quartz
+Business Insider
+Jamestown
+
+Interpretation. If total public‑security outlays have been ≥¥1 trillion annually since 2016, a ¥230–¥470bn wage‑only floor for the political‑monitoring labor component is plausible and likely conservative, because it excludes many sworn police salaries (outside DSD time) and non‑wage costs. On the other hand, not all “public security” spend is political surveillance (it also funds ordinary policing, courts/jails in some classifications, etc.). 
+Jamestown
+
+Why tech hasn’t displaced people (the Xinjiang micro‑case)
+
+During the Xinjiang security surge, authorities added >90,000 police in 2016–2017 and rolled out 7,300+ checkpoints, even as high‑tech systems expanded—clear evidence that technology scaled with headcount, not in place of it. 
+Wikipedia
+
+Cross‑country comparisons (how “manpower‑heavy” is China?)
+
+Key idea: China stands out not just for the size of its professional security services but for its massive neighborhood‑level human network (grid management) devoted to surveillance and early warning.
+
+Country / systemCore domestic‑intelligence staffAuxiliary / neighborhood “watchers”Spend / notes
+ChinaMSS: est. 100k–600k; MPS/DSD embedded nationwideGrid workers ~4.5m; Aux. police ≥1.2m (regulatory caps allow more; some locales up to 1.5:1 aux:sworn)Public security spend ≥¥1T since 2016; grid wages alone ~¥135–¥189bn/yr. 
+China News
+moj.gov.cn
+chinascope.org
+chinapeace.gov.cn
+Jamestown
+
+United StatesFBI total positions ~37,000 (domestic intel/counterintelligence plus criminal)No national grid; “fusion centers” exist but are small; local police not politically taskedFBI FY2025 budget ~$11.3B request. 
+Federal Bureau of Investigation
+
+United KingdomMI5 “over 5,000 staff”No mass neighborhood surveillance corpsUK intelligence funding via Single Intelligence Account (MI5/SIS/GCHQ); budget totals published but not MI5‑only. 
+MI5
+GOV.UK
+
+RussiaFSB numbers opaque; Rosgvardia ~340,000 internal troopsSome volunteer formations, but no nationwide “grid”Police staffing shortfalls ~172,000 recently signal overall scale; Rosgvardia underscores paramilitary role. 
+The Moscow Times
+Wall Street Journal
+
+VietnamMPS domestic security organs; sizes not public“Semi‑specialized force” reportedly ~2,000,000 local security collaboratorsIllustrates a PRC‑style community‑surveillance model in another one‑party state. 
+Wikipedia
+
+CubaSmall professional state securityCDR neighborhood committees ~8 million members (on paper; participation varies)Longstanding model of mass citizen surveillance; largely volunteer. 
+Wikipedia
+
+North KoreaState Security & Social Security Ministries; 140k–210k public security personnelUniversal inminban units (20–40 households each)The archetype of human‑mesh surveillance. 
+Wikipedia
+38 North
+
+What the table shows: Democracies concentrate domestic‑intelligence manpower in small professional agencies (thousands to tens of thousands). Authoritarian systems add or prioritize mass neighborhood networks (millions) to observe and feed information—China’s grid (~4.5m) is the standout contemporary example. 
+moj.gov.cn
+
+How I computed China’s cost & manpower (at a glance)
+
+Count what’s published: Grid workers 4.5m (official). Auxiliaries ≥1.2m (MPS data reported). Sworn police ~2.0m (historical/academic anchoring). MSS unknown → use a range tied to credible public estimates. 
+moj.gov.cn
+chinascope.org
+观察者网
+China Change
+China News
+
+Wage floor from postings: Grid ¥2.2–3.7k/month, Aux ~¥3.3–5.0k/month (higher in Tier‑1 cities). Multiply by headcount × 12. (This excludes social insurance, overtime, uniforms, vehicles, training.) 
+Sohu
+blog.sina.com.cn
+
+Cross‑check against the macro budget: PRC public‑security spend ≥¥1T since 2016—comfortably above the wage floor for monitoring labor, with room for overhead and technology. 
+Jamestown
+
+Uncertainty & what would most change the estimate
+
+MSS/DSD headcount and pay are the biggest missing pieces. A credible leak or MOF functional‑line breakout would tighten the range substantially. 
+Leiden Asia Centre
+
+Auxiliary police totals: MPS has acknowledged ≥1.2m; several provinces’ caps imply a theoretical upper bound near parity with sworn police (or higher). If auxiliaries are closer to 2–3m nationwide—as some local ratios suggest—the wage bill rises by ¥50–180bn. 
+chinascope.org
+jxrd.jxnews.com.cn
+chinapeace.gov.cn
+
+Grid‑worker pay varies with locality; moving the national median by ±¥500/month shifts the wage bill by about ±¥27bn.
+
+Bottom line
+
+Manpower applied to human monitoring in China is measured in the millions—~5–9 million if you count MSS/DSD and the nationwide grid alone, and >6 million FTEs when you account for police/auxiliary time on 维稳. The unique driver is the grid management system (网格化治理), not technology. 
+moj.gov.cn
+
+Annual labor cost for this monitoring—even on a conservative wage‑only basis—is likely in the low hundreds of billions of RMB (≈¥230–¥470bn), and plausibly higher once you include social charges and overhead embedded in the broader ≥¥1T public‑security outlays. 
+Jamestown
+
+Compared with peers, China’s system relies far more on mass human networks than on a compact professional cadre—closer in spirit to Cuba’s CDRs or Vietnam’s local security collaborators than to the FBI/MI5 model in democracies. 
+Wikipedia
++1
+Federal Bureau of Investigation
+MI5
+
+Sources (selected)
+
+PRC Ministry of Justice: 4.5 million grid workers, 583k governance centers. 
+moj.gov.cn
+
+Reuters & Jamestown on domestic security budgets (¥700–770bn in 2012–13; >¥1T by 2016). 
+Reuters
+Business Insider
+Jamestown
+
+60 Minutes interview citing MSS up to ~600k. 
+China News
+
+Historical and expert anchors on police numbers (1.43m in 2003; ~2m commonly cited today). 
+观察者网
+China Change
+
+Official/press postings on grid and auxiliary wages (Hubei case ~¥2,200/mo; Jinan ~¥3,700/mo; Beijing aux up to ~¥80–97k/yr; Tianjin/Guangdong ~¥3,300–¥5,000/mo). 
+Sohu
++1
+blog.sina.com.cn
+
+Xinjiang surge (>90k police recruited 2016–17) showing manpower intensification alongside tech. 
+Wikipedia
+
+Comparators: FBI staffing/budget; MI5 staff; Rosgvardia size & Russian police staffing shortfall; Vietnam MPS “semi‑specialized force” ~2m; Cuba CDR ~8m; North Korea inminban and police. 
+Federal Bureau of Investigation
+MI5
+The Moscow Times
+Wall Street Journal
+Wikipedia
++2
+Wikipedia
++2
+38 North


### PR DESCRIPTION
## Summary
- replace China human monitoring report with detailed estimates of dedicated political-security staff, police and grid workers
- add wage and budget calculations for monitoring labor
- include cross-country comparisons of surveillance manpower

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab3d6909a0832d9644367cda1cf089