### PR TITLE
Cross-reference shell-company links to LinkedIn personas

### DIFF
--- a/shell-companies/README.md
+++ b/shell-companies/README.md
@@ -4,6 +4,14 @@ LinkedIn has identified and removed shell companies that sold large-scale automa
 
 These shell-company offerings are part of the broader infiltration tradecraft documented in [MSS LinkedIn Infiltration Analysis](../MSS_LinkedIn_Infiltration_Analysis__CLAUDE.md). By supplying clusters of ready-made fake identities, they enable coordinated persona clusters like those cataloged in [LinkedIn](../LinkedIn/).
 
+The mass-produced profiles marketed by these firms are injected directly into persona clusters such as the [Sesame](../LinkedIn/Sesame/README.md) investigation, where multiple synthetic accounts share employers, messaging templates, and connection patterns.
+
+## Related Case Studies and Datasets
+
+- [Kevin Mallory](../case-studies/kevin-mallory/README.md) – demonstrates how LinkedIn personas can progress from routine contact to espionage recruitment.
+- [Yanjun Xu](../case-studies/yanjun-xu/README.md) – shows the role of front companies and talent programs that echo shell-company outreach.
+- [`fake_profiles.csv`](../datasets/fake_profiles.csv) – dataset of suspected synthetic LinkedIn identities, many sourced from shell-company automation services.
+
 ## LIA
 
 LIA marketed clusters of fake LinkedIn profiles complete with AI-generated avatars, job histories, and connection scripts. For roughly $300 a month, clients received dozens of ready-to-use identities and message templates. LinkedIn has since removed LIA's company page and associated accounts for violating platform policies.


### PR DESCRIPTION
## Summary
- Detail how shell-company services feed into LinkedIn persona clusters such as the Sesame investigation.
- Cross-reference Kevin Mallory and Yanjun Xu case studies and the `fake_profiles.csv` dataset for context.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab40e163b0832d9d33853dd23f93fa