### PR TITLE
Fix MCF University report link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The repository tracks open-source evidence of long-term influence operations att
 - [LinkedIn/](LinkedIn/) – reports and data tied to LinkedIn investigations, including cluster-specific folders such as `Sesame/`.
 - [case-studies/](case-studies/) – narrative reports examining individual operations.
 - [Intelligence-Analyst/](Intelligence-Analyst/) – planning documents and research schedules for analyst workflows.
-- [institutions/](institutions/) – institution dossiers with infiltration reports; each subfolder covers a specific organization, such as the [MCF University infiltration report](institutions/MCF_University/MCF_University_Infiltration_Report.md).
+- [institutions/](institutions/) – institution dossiers with infiltration reports; examples include the [MCF University infiltration report](MCF_University_Infiltration_Report.md).
 - [shell-companies/](shell-companies/) – information on commercial services enabling large-scale persona creation.
 - [MSS_LinkedIn_Infiltration_Analysis__CLAUDE.md](MSS_LinkedIn_Infiltration_Analysis__CLAUDE.md) – analysis of LinkedIn infiltration tactics.
 - Additional folders contain references, draft reports, and test suites.


### PR DESCRIPTION
## Summary
- Corrected the institutions section to link directly to `MCF_University_Infiltration_Report.md`.
- Verified that all other top-level README links point to existing files or directories.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab40dce7a8832daa25f4b6f36385d4