### PR TITLE
Cross-reference Sesame investigation docs

### DIFF
--- a/LinkedIn/Sesame/Fabrication-Suspected/README.md
+++ b/LinkedIn/Sesame/Fabrication-Suspected/README.md
@@ -1,9 +1,22 @@
 # Fabrication-Suspected LinkedIn Profiles
 
-This directory contains subfolders for personas believed to be AI-fabricated. Each profile includes:
+This directory contains subfolders for personas believed to be AI-fabricated. For broader context, see the parent [LinkedIn README](../../README.md).
+
+Each profile includes:
 
 - `*_profile_full.png` – screenshot of the full LinkedIn profile image.
 - Feature crops such as `eyes.png` or `nose.png` and their corresponding `*_AIDR.png` overlays highlighting anomalies found by the AI-image-detection pipeline (AIDR).
 - Images may contain embedded text captured through OCR.
 
 Summary statistics and probabilities derived from these AIDR outputs are tracked in `RESULTS.md`.
+
+## Related Datasets
+- [`fake_profiles.csv`](../../../datasets/fake_profiles.csv) – suspected synthetic or compromised LinkedIn profiles.
+
+## Related Case Studies
+- [Kevin Mallory](../../../case-studies/kevin-mallory/README.md) – contacted via LinkedIn and convicted of espionage.
+- [Yanjun Xu](../../../case-studies/yanjun-xu/README.md) – used talent recruitment programs for technology theft.
+
+## Related Institutions
+- [Sesame](../../../institutions/sesame/README.md) – corporate background and linked personas.
+- [Zinn Labs](../../../institutions/zinn-labs/README.md) – acquisition details and technology considerations.

--- a/LinkedIn/Sesame/Identity-Theft-Suspected/Brendan-Iribe/README.md
+++ b/LinkedIn/Sesame/Identity-Theft-Suspected/Brendan-Iribe/README.md
@@ -1,3 +1,16 @@
 # Brendan Iribe – Suspected Identity Theft
 
 This folder holds Google search results, Google profile screenshots and Instagram posts linked to Brendan Iribe. Several images show Iribe with fellow Oculus co-founder Nate Mitchell, reinforcing their association. The LinkedIn persona under review appears to reuse these public images, suggesting the account may impersonate the Oculus co-founder. Open-source queries also pair Iribe’s name with Sesame, albeit loosely. Embedded text in the screenshots can be extracted via OCR for deeper investigation.
+
+For project navigation, see the parent [LinkedIn README](../../../README.md).
+
+## Related Datasets
+- [`fake_profiles.csv`](../../../../datasets/fake_profiles.csv) – suspected synthetic or compromised LinkedIn profiles.
+
+## Related Case Studies
+- [Kevin Mallory](../../../../case-studies/kevin-mallory/README.md) – contacted via LinkedIn and convicted of espionage.
+- [Yanjun Xu](../../../../case-studies/yanjun-xu/README.md) – used talent recruitment programs for technology theft.
+
+## Related Institutions
+- [Sesame](../../../../institutions/sesame/README.md) – corporate background and linked personas.
+- [Zinn Labs](../../../../institutions/zinn-labs/README.md) – acquisition details and technology considerations.

--- a/LinkedIn/Sesame/Identity-Theft-Suspected/Gordon-Wetzstein/README.md
+++ b/LinkedIn/Sesame/Identity-Theft-Suspected/Gordon-Wetzstein/README.md
@@ -1,3 +1,17 @@
 # Gordon Wetzstein – Suspected Identity Theft
 
 Contains a single photo (`IMG_7370.png`) believed to show the real Gordon Wetzstein. The LinkedIn profile in question likely reuses this image without authorization, indicating a stolen identity scenario. Wetzstein co-founded Zinn Labs, reportedly acquired by Sesame, and is currently unreachable—possibly on sabbatical in a remote area until April 2026. Any text embedded in the image can be extracted with OCR tools.
+
+For project navigation, see the parent [LinkedIn README](../../../README.md).
+
+## Related Datasets
+- [`fake_profiles.csv`](../../../../datasets/fake_profiles.csv) – suspected synthetic or compromised LinkedIn profiles.
+
+## Related Case Studies
+- [Kevin Mallory](../../../../case-studies/kevin-mallory/README.md) – contacted via LinkedIn and convicted of espionage.
+- [Yanjun Xu](../../../../case-studies/yanjun-xu/README.md) – used talent recruitment programs for technology theft.
+
+## Related Institutions
+- [Sesame](../../../../institutions/sesame/README.md) – corporate background and linked personas.
+- [Zinn Labs](../../../../institutions/zinn-labs/README.md) – acquisition details and technology considerations.
+- [Stanford University](../../../../institutions/stanford/README.md) – affiliation of Gordon Wetzstein.

--- a/LinkedIn/Sesame/Identity-Theft-Suspected/Nate-Mitchell/README.md
+++ b/LinkedIn/Sesame/Identity-Theft-Suspected/Nate-Mitchell/README.md
@@ -1,3 +1,16 @@
 # Nate Mitchell – Suspected Identity Theft
 
 Screenshots here capture Google and Reddit search results, a Forbes reference, a private Instagram page and an X profile for the real Nate Mitchell. They also show ties to fellow Oculus co-founder Brendan Iribe. The LinkedIn account examined may be exploiting these images, pointing to possible identity theft and loosely linking Mitchell with Sesame. OCR on these screenshots can surface additional metadata.
+
+For project navigation, see the parent [LinkedIn README](../../../README.md).
+
+## Related Datasets
+- [`fake_profiles.csv`](../../../../datasets/fake_profiles.csv) – suspected synthetic or compromised LinkedIn profiles.
+
+## Related Case Studies
+- [Kevin Mallory](../../../../case-studies/kevin-mallory/README.md) – contacted via LinkedIn and convicted of espionage.
+- [Yanjun Xu](../../../../case-studies/yanjun-xu/README.md) – used talent recruitment programs for technology theft.
+
+## Related Institutions
+- [Sesame](../../../../institutions/sesame/README.md) – corporate background and linked personas.
+- [Zinn Labs](../../../../institutions/zinn-labs/README.md) – acquisition details and technology considerations.

--- a/LinkedIn/Sesame/Identity-Theft-Suspected/README.md
+++ b/LinkedIn/Sesame/Identity-Theft-Suspected/README.md
@@ -1,6 +1,6 @@
 # Identity-Theft-Suspected LinkedIn Profiles
 
-Evidence in this directory indicates that certain LinkedIn accounts may reuse photographs of real individuals without consent. Subfolders document each potential victim and include screenshots of search results, social media pages, or other public sources. Many images carry OCR-extractable text for further analysis.
+Evidence in this directory indicates that certain LinkedIn accounts may reuse photographs of real individuals without consent. For broader navigation of the project, see the parent [LinkedIn README](../../README.md). Subfolders document each potential victim and include screenshots of search results, social media pages, or other public sources. Many images carry OCR-extractable text for further analysis.
 
 ## Suspected personas
 - **Brendan Iribe** – Google search results, profile screenshots, and Instagram posts appear reused by a LinkedIn persona impersonating the Oculus co-founder and associating him with Nate Mitchell.
@@ -8,3 +8,15 @@ Evidence in this directory indicates that certain LinkedIn accounts may reuse ph
 - **Nate Mitchell** – Search results, a Forbes mention, and social media profiles mirror a LinkedIn account that may exploit his images while loosely linking him with Sesame.
 
 All three names surface in open-source searches alongside Sesame, supporting the identity-theft suspicion.
+
+## Related Datasets
+- [`fake_profiles.csv`](../../../datasets/fake_profiles.csv) – suspected synthetic or compromised LinkedIn profiles.
+
+## Related Case Studies
+- [Kevin Mallory](../../../case-studies/kevin-mallory/README.md) – contacted via LinkedIn and convicted of espionage.
+- [Yanjun Xu](../../../case-studies/yanjun-xu/README.md) – used talent recruitment programs for technology theft.
+
+## Related Institutions
+- [Sesame](../../../institutions/sesame/README.md) – corporate background and linked personas.
+- [Zinn Labs](../../../institutions/zinn-labs/README.md) – acquisition details and technology considerations.
+- [Stanford University](../../../institutions/stanford/README.md) – affiliation of professor Gordon Wetzstein.

--- a/LinkedIn/Sesame/README.md
+++ b/LinkedIn/Sesame/README.md
@@ -1,6 +1,6 @@
 # Sesame Persona Investigation
 
-This folder consolidates evidence on LinkedIn accounts linked to the company "Sesame" and suspected of using fabricated or stolen identities.
+This folder consolidates evidence on LinkedIn accounts linked to the company "Sesame" and suspected of using fabricated or stolen identities. For broader context on the overall investigation, consult the parent [LinkedIn README](../README.md).
 See [LinkedIn Infiltration Research Plan](../../Intelligence-Analyst/LinkedIn_Infiltration_Research_Plan.md) for methodology.
 
 ## Key Items
@@ -13,6 +13,15 @@ See [LinkedIn Infiltration Research Plan](../../Intelligence-Analyst/LinkedIn_In
 
 Current findings indicate no U.S. export ban on Zinn Labs' eye-tracking technology and no credible evidence that Sesame acts as an MSS front. However, open-source voice models could still be misused for impersonation or social engineering.
 
+## Related Datasets
+- [`fake_profiles.csv`](../../datasets/fake_profiles.csv) – suspected synthetic or compromised LinkedIn profiles.
+- [`mcf_institution_partnerships.csv`](../../datasets/mcf_institution_partnerships.csv) – collaborations touching Sesame and Zinn Labs.
+
+## Related Case Studies
+- [Kevin Mallory](../../case-studies/kevin-mallory/README.md) – contacted via LinkedIn and convicted of espionage.
+- [Yanjun Xu](../../case-studies/yanjun-xu/README.md) – used talent recruitment programs for technology theft.
+
 ## Related Institutions
 - [Sesame](../../institutions/sesame/README.md) – corporate background and linked personas.
 - [Zinn Labs](../../institutions/zinn-labs/README.md) – acquisition details and technology considerations.
+- [Stanford University](../../institutions/stanford/README.md) – affiliation of professor Gordon Wetzstein, cited in identity-theft leads.

--- a/LinkedIn/Sesame/Zinn-Labs (acquisition)/README.md
+++ b/LinkedIn/Sesame/Zinn-Labs (acquisition)/README.md
@@ -1,9 +1,20 @@
 # Zinn Labs Acquisition
 
-This directory gathers open-source material about Sesame's reported acquisition of Zinn Labs.
+This directory gathers open-source material about Sesame's reported acquisition of Zinn Labs. For broader context, see the parent [LinkedIn README](../../README.md).
 
 ## Contents
 - `Zinn-Labs_profile_full.png` – full LinkedIn profile screenshot.
 - `Zinn-Labs_Google_profile.png` and related images – search results and articles connecting Zinn Labs to Prophesee and Chinese partnerships.
 - `Zinn-Labs_Website.png` – capture of the corporate site prior to acquisition.
 - `event-based-gaze-risk-report.md` – summary of event-based gaze tracking risks and mitigations.
+
+## Related Datasets
+- [`mcf_institution_partnerships.csv`](../../../datasets/mcf_institution_partnerships.csv) – academic collaborations relevant to Sesame and Zinn Labs.
+
+## Related Case Studies
+- [Kevin Mallory](../../../case-studies/kevin-mallory/README.md) – contacted via LinkedIn and convicted of espionage.
+- [Yanjun Xu](../../../case-studies/yanjun-xu/README.md) – used talent recruitment programs for technology theft.
+
+## Related Institutions
+- [Sesame](../../../institutions/sesame/README.md) – corporate background and linked personas.
+- [Zinn Labs](../../../institutions/zinn-labs/README.md) – acquisition details and technology considerations.


### PR DESCRIPTION
## Summary
- add navigation links to parent LinkedIn README in Sesame investigation docs
- reference related datasets, case studies, and institution dossiers across Sesame subfolders

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab40e4d76c832d9bbbbf6db8c4837e