### PR TITLE
Add hyperlinks to China monitoring report references

### DIFF
--- a/research/china_human_monitoring_report.md
+++ b/research/china_human_monitoring_report.md
@@ -2,31 +2,31 @@
 
 ## A. Dedicated political-security professionals (core "political police")
 
-- **MSS (Ministry of State Security)** – size is secret; credible public estimates run from the low hundreds of thousands up to ~600,000 employees (e.g., former U.S. official James Lewis told 60 Minutes "as many as 600,000"). China News
+- **MSS (Ministry of State Security)** – size is secret; credible public estimates run from the low hundreds of thousands up to ~600,000 employees (e.g., former U.S. official James Lewis told 60 Minutes "as many as 600,000"). [China News](https://www.chinanews.com.cn)
 
-- **MPS Domestic Security Department (国保/DSD)** – the MPS’ political-security arm is present down to municipal level; numbers are not public but the unit’s function and priority are well documented. For estimation below, DSD is treated as a share of MPS sworn police (see B). Leiden Asia Centre
+- **MPS Domestic Security Department (国保/DSD)** – the MPS’ political-security arm is present down to municipal level; numbers are not public but the unit’s function and priority are well documented. For estimation below, DSD is treated as a share of MPS sworn police (see B). [Leiden Asia Centre](https://leidenasiacentre.nl)
 
 ## B. Police & auxiliaries who do political monitoring as part of "stability maintenance" (维稳)
 
-- **Sworn police (MPS)** – China does not publish a current national figure; historical and expert references place it around 2 million today (1.43 million in 2003; commonly cited ~2 million now). 观察者网 China Change
+- **Sworn police (MPS)** – China does not publish a current national figure; historical and expert references place it around 2 million today (1.43 million in 2003; commonly cited ~2 million now). [观察者网](https://www.guancha.cn) [China Change](https://chinachange.org)
 
-  - *Rationale*: 2003 MPS data showed 1.43m police; since then both population and police density rose, and academic work on Chinese policing uses ~2m as an order-of-magnitude anchor. 观察者网 Leiden Asia Centre
+  - *Rationale*: 2003 MPS data showed 1.43m police; since then both population and police density rose, and academic work on Chinese policing uses ~2m as an order-of-magnitude anchor. [观察者网](https://www.guancha.cn) [Leiden Asia Centre](https://leidenasiacentre.nl)
 
-- **Auxiliary police (辅警)** – para-police on local payrolls. ≥1.2 million nationwide by end-2024 (MPS data, reported); several provinces cap auxiliaries at or below the number of sworn police, with some local ratios up to 1.5 auxiliaries per officer. chinascope.org jxrd.jxnews.com.cn chinapeace.gov.cn
+- **Auxiliary police (辅警)** – para-police on local payrolls. ≥1.2 million nationwide by end-2024 (MPS data, reported); several provinces cap auxiliaries at or below the number of sworn police, with some local ratios up to 1.5 auxiliaries per officer. [chinascope.org](https://chinascope.org) [jxrd.jxnews.com.cn](https://jxrd.jxnews.com.cn) [chinapeace.gov.cn](https://www.chinapeace.gov.cn)
 
 ## C. Full-time neighborhood "grid" managers (网格员)
 
-- **Grid workers** – ~4.5 million nationwide, per the PRC Ministry of Justice. They staff 583,000 "comprehensive governance centers" and act as eyes/ears for local Political-Legal Committees. moj.gov.cn
+- **Grid workers** – ~4.5 million nationwide, per the PRC Ministry of Justice. They staff 583,000 "comprehensive governance centers" and act as eyes/ears for local Political-Legal Committees. [moj.gov.cn](https://www.moj.gov.cn)
 
 ## Bringing it together (headcount ranges)
 
-- **Dedicated political-security** (MSS + DSD): very uncertain; a defensible working range = 300k–900k (MSS 100k–600k + a fraction of MPS assigned to DSD tasks). China News Leiden Asia Centre
+- **Dedicated political-security** (MSS + DSD): very uncertain; a defensible working range = 300k–900k (MSS 100k–600k + a fraction of MPS assigned to DSD tasks). [China News](https://www.chinanews.com.cn) [Leiden Asia Centre](https://leidenasiacentre.nl)
 
-- **Police & auxiliaries** (part-time political monitoring): ~3.2m (≈2.0m sworn + ≥1.2m auxiliaries), of whom only a share of time is political/security monitoring. chinascope.org China Change
+- **Police & auxiliaries** (part-time political monitoring): ~3.2m (≈2.0m sworn + ≥1.2m auxiliaries), of whom only a share of time is political/security monitoring. [chinascope.org](https://chinascope.org) [China Change](https://chinachange.org)
 
-- **Neighborhood grid managers** (full-time monitoring): ~4.5m. moj.gov.cn
+- **Neighborhood grid managers** (full-time monitoring): ~4.5m. [moj.gov.cn](https://www.moj.gov.cn)
 
-**Order-of-magnitude takeaway**: Counting people whose primary job is feeding, doing, or coordinating political/domestic surveillance (MSS + DSD + grid) yields ~5–9 million people (broad band because MSS and DSD headcounts are opaque). Including sworn/auxiliary police time spent on 维稳 duties, the labor applied to human monitoring on any given day plausibly sits well above 6 million FTEs (grid + dedicated units + a slice of police/aux time). The official 4.5 million grid workers alone make this an unusually manpower-intensive system by global standards. moj.gov.cn
+**Order-of-magnitude takeaway**: Counting people whose primary job is feeding, doing, or coordinating political/domestic surveillance (MSS + DSD + grid) yields ~5–9 million people (broad band because MSS and DSD headcounts are opaque). Including sworn/auxiliary police time spent on 维稳 duties, the labor applied to human monitoring on any given day plausibly sits well above 6 million FTEs (grid + dedicated units + a slice of police/aux time). The official 4.5 million grid workers alone make this an unusually manpower-intensive system by global standards. [moj.gov.cn](https://www.moj.gov.cn)
 
 ## China: what does this cost? (wage bill and budget anchors)
 
@@ -34,74 +34,74 @@ The central budget no longer itemizes all "domestic security" sub-lines. A floor
 
 ### 1. Bottom-up "floor" wage bill (direct human monitoring)
 
-- **Grid workers (~4.5m)** – public postings show monthly base pay typically ¥2,200–¥3,700 (examples from Hubei, Beijing Shunyi, Jinan). Annual wage bill ≈ ¥135–¥189 billion. China Change
+- **Grid workers (~4.5m)** – public postings show monthly base pay typically ¥2,200–¥3,700 (examples from Hubei, Beijing Shunyi, Jinan). Annual wage bill ≈ ¥135–¥189 billion. [China Change](https://chinachange.org)
 
-- **Auxiliary police (≥1.2m)** – often ¥3,300–¥5,000 RMB/month, higher in some cities (e.g., Guangdong/Jiangsu/Tianjin postings; Beijing positions approach ¥80k–97k/yr packages). Annual wage bill = ¥48–¥120+ billion at 1.2m auxiliaries (larger if closer to 2m). Sohu +1 blog.sina.com.cn
+- **Auxiliary police (≥1.2m)** – often ¥3,300–¥5,000 RMB/month, higher in some cities (e.g., Guangdong/Jiangsu/Tianjin postings; Beijing positions approach ¥80k–97k/yr packages). Annual wage bill = ¥48–¥120+ billion at 1.2m auxiliaries (larger if closer to 2m). [Sohu](https://www.sohu.com) +1 [blog.sina.com.cn](https://blog.sina.com.cn)
 
-- **MSS + MPS/DSD cadre** – no open wage data; illustrative bracket: if 300k–900k personnel average ¥120k–¥180k/yr, that's ¥36–¥162 billion in salaries (scenario calculation, not official). Leiden Asia Centre China News
+- **MSS + MPS/DSD cadre** – no open wage data; illustrative bracket: if 300k–900k personnel average ¥120k–¥180k/yr, that's ¥36–¥162 billion in salaries (scenario calculation, not official). [Leiden Asia Centre](https://leidenasiacentre.nl) [China News](https://www.chinanews.com.cn)
 
 → **Conservative "floor" for wages directly tied to human monitoring labor**: ~¥230–¥470 billion per year (grid + auxiliaries + plausible band for MSS/DSD), before employer social contributions, housing funds, training, overhead, and equipment.
 
 ### 2. Top-down cross-check (domestic security budgets)
 
-PRC "public security" (domestic) spending across all levels reached ¥702bn (2012) and ¥769bn (2013); by 2016 it exceeded ¥1 trillion, outpacing defense that year. Later budgets became harder to disaggregate publicly, but the level remaining ≥¥1T from the mid-2010s is well documented. Reuters Quartz Business Insider Jamestown
+PRC "public security" (domestic) spending across all levels reached ¥702bn (2012) and ¥769bn (2013); by 2016 it exceeded ¥1 trillion, outpacing defense that year. Later budgets became harder to disaggregate publicly, but the level remaining ≥¥1T from the mid-2010s is well documented. [Reuters](https://www.reuters.com) [Quartz](https://qz.com) [Business Insider](https://www.businessinsider.com) [Jamestown](https://jamestown.org)
 
-**Interpretation**: If total public-security outlays have been ≥¥1 trillion annually since 2016, a ¥230–¥470bn wage-only floor for the political-monitoring labor component is plausible and likely conservative, because it excludes many sworn police salaries (outside DSD time) and non-wage costs. Not all "public security" spend is political surveillance (it also funds ordinary policing, courts/jails in some classifications, etc.). Jamestown
+**Interpretation**: If total public-security outlays have been ≥¥1 trillion annually since 2016, a ¥230–¥470bn wage-only floor for the political-monitoring labor component is plausible and likely conservative, because it excludes many sworn police salaries (outside DSD time) and non-wage costs. Not all "public security" spend is political surveillance (it also funds ordinary policing, courts/jails in some classifications, etc.). [Jamestown](https://jamestown.org)
 
 ## Why tech hasn’t displaced people (the Xinjiang micro-case)
 
-During the Xinjiang security surge, authorities added >90,000 police in 2016–2017 and rolled out 7,300+ checkpoints, even as high-tech systems expanded—clear evidence that technology scaled with headcount, not in place of it. Wikipedia
+During the Xinjiang security surge, authorities added >90,000 police in 2016–2017 and rolled out 7,300+ checkpoints, even as high-tech systems expanded—clear evidence that technology scaled with headcount, not in place of it. [Wikipedia](https://www.wikipedia.org)
 
 ## Cross-country comparisons (how "manpower-heavy" is China?)
 
 | Country / system | Core domestic-intelligence staff | Auxiliary / neighborhood "watchers" | Spend / notes |
 | --- | --- | --- | --- |
-| **China** | MSS: est. 100k–600k; MPS/DSD embedded nationwide | Grid workers ~4.5m; Aux. police ≥1.2m (regulatory caps allow more; some locales up to 1.5:1 aux:sworn) | Public security spend ≥¥1T since 2016; grid wages alone ~¥135–¥189bn/yr. China News moj.gov.cn chinascope.org chinapeace.gov.cn Jamestown |
-| **United States** | FBI total positions ~37,000 (domestic intel/counterintelligence plus criminal) | No national grid; "fusion centers" exist but are small; local police not politically tasked | FBI FY2025 budget ~$11.3B request. Federal Bureau of Investigation |
-| **United Kingdom** | MI5 "over 5,000 staff" | No mass neighborhood surveillance corps | UK intelligence funding via Single Intelligence Account (MI5/SIS/GCHQ); budget totals published but not MI5-only. MI5 GOV.UK |
-| **Russia** | FSB numbers opaque; Rosgvardia ~340,000 internal troops | Some volunteer formations, but no nationwide "grid"; police staffing shortfalls ~172,000 recently signal overall scale; Rosgvardia underscores paramilitary role. | The Moscow Times Wall Street Journal |
-| **Vietnam** | MPS domestic security organs; sizes not public | "Semi-specialized force" reportedly ~2,000,000 local security collaborators | Illustrates a PRC-style community-surveillance model in another one-party state. Wikipedia |
-| **Cuba** | Small professional state security | CDR neighborhood committees ~8 million members (on paper; participation varies) | Longstanding model of mass citizen surveillance; largely volunteer. Wikipedia |
-| **North Korea** | State Security & Social Security Ministries; 140k–210k public security personnel | Universal inminban units (20–40 households each) | The archetype of human-mesh surveillance. Wikipedia 38 North |
+| **China** | MSS: est. 100k–600k; MPS/DSD embedded nationwide | Grid workers ~4.5m; Aux. police ≥1.2m (regulatory caps allow more; some locales up to 1.5:1 aux:sworn) | Public security spend ≥¥1T since 2016; grid wages alone ~¥135–¥189bn/yr. [China News](https://www.chinanews.com.cn) [moj.gov.cn](https://www.moj.gov.cn) [chinascope.org](https://chinascope.org) [chinapeace.gov.cn](https://www.chinapeace.gov.cn) [Jamestown](https://jamestown.org) |
+| **United States** | [FBI](https://www.fbi.gov) total positions ~37,000 (domestic intel/counterintelligence plus criminal) | No national grid; "fusion centers" exist but are small; local police not politically tasked | [FBI](https://www.fbi.gov) FY2025 budget ~$11.3B request. [Federal Bureau of Investigation](https://www.fbi.gov) |
+| **United Kingdom** | [MI5](https://www.mi5.gov.uk) "over 5,000 staff" | No mass neighborhood surveillance corps | UK intelligence funding via Single Intelligence Account ([MI5](https://www.mi5.gov.uk)/SIS/GCHQ); budget totals published but not [MI5](https://www.mi5.gov.uk)-only. [MI5](https://www.mi5.gov.uk) [GOV.UK](https://www.gov.uk) |
+| **Russia** | FSB numbers opaque; Rosgvardia ~340,000 internal troops | Some volunteer formations, but no nationwide "grid"; police staffing shortfalls ~172,000 recently signal overall scale; Rosgvardia underscores paramilitary role. | [The Moscow Times](https://www.themoscowtimes.com) [Wall Street Journal](https://www.wsj.com) |
+| **Vietnam** | MPS domestic security organs; sizes not public | "Semi-specialized force" reportedly ~2,000,000 local security collaborators | Illustrates a PRC-style community-surveillance model in another one-party state. [Wikipedia](https://www.wikipedia.org) |
+| **Cuba** | Small professional state security | CDR neighborhood committees ~8 million members (on paper; participation varies) | Longstanding model of mass citizen surveillance; largely volunteer. [Wikipedia](https://www.wikipedia.org) |
+| **North Korea** | State Security & Social Security Ministries; 140k–210k public security personnel | Universal inminban units (20–40 households each) | The archetype of human-mesh surveillance. [Wikipedia](https://www.wikipedia.org) [38 North](https://www.38north.org) |
 
-**What the table shows**: Democracies concentrate domestic-intelligence manpower in small professional agencies (thousands to tens of thousands). Authoritarian systems add or prioritize mass neighborhood networks (millions) to observe and feed information—China’s grid (~4.5m) is the standout contemporary example. moj.gov.cn
+**What the table shows**: Democracies concentrate domestic-intelligence manpower in small professional agencies (thousands to tens of thousands). Authoritarian systems add or prioritize mass neighborhood networks (millions) to observe and feed information—China’s grid (~4.5m) is the standout contemporary example. [moj.gov.cn](https://www.moj.gov.cn)
 
 ## How I computed China's cost & manpower (at a glance)
 
-1. **Count what's published**: grid workers 4.5m (official); auxiliaries ≥1.2m (MPS data reported); sworn police ~2.0m (historical/academic anchoring); MSS unknown → use a range tied to credible public estimates. moj.gov.cn chinascope.org 观察者网 China Change China News
+1. **Count what's published**: grid workers 4.5m (official); auxiliaries ≥1.2m (MPS data reported); sworn police ~2.0m (historical/academic anchoring); MSS unknown → use a range tied to credible public estimates. [moj.gov.cn](https://www.moj.gov.cn) [chinascope.org](https://chinascope.org) [观察者网](https://www.guancha.cn) [China Change](https://chinachange.org) [China News](https://www.chinanews.com.cn)
 
-2. **Wage floor from postings**: grid ¥2.2–3.7k/month, aux ~¥3.3–5.0k/month (higher in Tier-1 cities). Multiply by headcount × 12 (excludes social insurance, overtime, uniforms, vehicles, training). Sohu blog.sina.com.cn
+2. **Wage floor from postings**: grid ¥2.2–3.7k/month, aux ~¥3.3–5.0k/month (higher in Tier-1 cities). Multiply by headcount × 12 (excludes social insurance, overtime, uniforms, vehicles, training). [Sohu](https://www.sohu.com) [blog.sina.com.cn](https://blog.sina.com.cn)
 
-3. **Cross-check against the macro budget**: PRC public-security spend ≥¥1T since 2016—comfortably above the wage floor for monitoring labor, with room for overhead and technology. Jamestown
+3. **Cross-check against the macro budget**: PRC public-security spend ≥¥1T since 2016—comfortably above the wage floor for monitoring labor, with room for overhead and technology. [Jamestown](https://jamestown.org)
 
 ## Uncertainty & what would most change the estimate
 
-- MSS/DSD headcount and pay are the biggest missing pieces; a credible leak or MOF functional-line breakout would tighten the range substantially. Leiden Asia Centre
+- MSS/DSD headcount and pay are the biggest missing pieces; a credible leak or MOF functional-line breakout would tighten the range substantially. [Leiden Asia Centre](https://leidenasiacentre.nl)
 
-- Auxiliary police totals: MPS has acknowledged ≥1.2m; several provinces’ caps imply a theoretical upper bound near parity with sworn police (or higher). If auxiliaries are closer to 2–3m nationwide—as some local ratios suggest—the wage bill rises by ¥50–180bn. chinascope.org jxrd.jxnews.com.cn chinapeace.gov.cn
+- Auxiliary police totals: MPS has acknowledged ≥1.2m; several provinces’ caps imply a theoretical upper bound near parity with sworn police (or higher). If auxiliaries are closer to 2–3m nationwide—as some local ratios suggest—the wage bill rises by ¥50–180bn. [chinascope.org](https://chinascope.org) [jxrd.jxnews.com.cn](https://jxrd.jxnews.com.cn) [chinapeace.gov.cn](https://www.chinapeace.gov.cn)
 
 - Grid-worker pay varies with locality; moving the national median by ±¥500/month shifts the wage bill by about ±¥27bn.
 
 ## Bottom line
 
-Manpower applied to human monitoring in China is measured in the millions—~5–9 million if you count MSS/DSD and the nationwide grid alone, and >6 million FTEs when you account for police/auxiliary time on 维稳. The unique driver is the grid management system (网格化治理), not technology. moj.gov.cn
+Manpower applied to human monitoring in China is measured in the millions—~5–9 million if you count MSS/DSD and the nationwide grid alone, and >6 million FTEs when you account for police/auxiliary time on 维稳. The unique driver is the grid management system (网格化治理), not technology. [moj.gov.cn](https://www.moj.gov.cn)
 
-Annual labor cost for this monitoring—on a conservative wage-only basis—is likely in the low hundreds of billions of RMB (≈¥230–¥470bn), and plausibly higher once you include social charges and overhead embedded in the broader ≥¥1T public-security outlays. Jamestown
+Annual labor cost for this monitoring—on a conservative wage-only basis—is likely in the low hundreds of billions of RMB (≈¥230–¥470bn), and plausibly higher once you include social charges and overhead embedded in the broader ≥¥1T public-security outlays. [Jamestown](https://jamestown.org)
 
-Compared with peers, China’s system relies far more on mass human networks than on a compact professional cadre—closer in spirit to Cuba’s CDRs or Vietnam’s local security collaborators than to the FBI/MI5 model in democracies. Wikipedia +1 Federal Bureau of Investigation MI5
+Compared with peers, China’s system relies far more on mass human networks than on a compact professional cadre—closer in spirit to Cuba’s CDRs or Vietnam’s local security collaborators than to the [FBI](https://www.fbi.gov)/[MI5](https://www.mi5.gov.uk) model in democracies. [Wikipedia](https://www.wikipedia.org) +1 [Federal Bureau of Investigation](https://www.fbi.gov) [MI5](https://www.mi5.gov.uk)
 
 ## Sources (selected)
 
-- PRC Ministry of Justice: 4.5 million grid workers, 583k governance centers. moj.gov.cn
+- PRC Ministry of Justice: 4.5 million grid workers, 583k governance centers. [moj.gov.cn](https://www.moj.gov.cn)
 
-- Reuters & Jamestown on domestic security budgets (¥700–770bn in 2012–13; >¥1T by 2016). Reuters Business Insider Jamestown
+- [Reuters](https://www.reuters.com) & [Jamestown](https://jamestown.org) on domestic security budgets (¥700–770bn in 2012–13; >¥1T by 2016). [Reuters](https://www.reuters.com) [Business Insider](https://www.businessinsider.com) [Jamestown](https://jamestown.org)
 
-- 60 Minutes interview citing MSS up to ~600k. China News
+- 60 Minutes interview citing MSS up to ~600k. [China News](https://www.chinanews.com.cn)
 
-- Historical and expert anchors on police numbers (1.43m in 2003; ~2m commonly cited today). 观察者网 China Change
+- Historical and expert anchors on police numbers (1.43m in 2003; ~2m commonly cited today). [观察者网](https://www.guancha.cn) [China Change](https://chinachange.org)
 
-- Official/press postings on grid and auxiliary wages (Hubei case ~¥2,200/mo; Jinan ~¥3,700/mo; Beijing aux up to ~¥80–97k/yr; Tianjin/Guangdong ~¥3,300–¥5,000/mo). Sohu +1 blog.sina.com.cn
+- Official/press postings on grid and auxiliary wages (Hubei case ~¥2,200/mo; Jinan ~¥3,700/mo; Beijing aux up to ~¥80–97k/yr; Tianjin/Guangdong ~¥3,300–¥5,000/mo). [Sohu](https://www.sohu.com) +1 [blog.sina.com.cn](https://blog.sina.com.cn)
 
-- Xinjiang surge (>90k police recruited 2016–17) showing manpower intensification alongside tech. Wikipedia
+- Xinjiang surge (>90k police recruited 2016–17) showing manpower intensification alongside tech. [Wikipedia](https://www.wikipedia.org)
 
-- Comparators: FBI staffing/budget; MI5 staff; Rosgvardia size & Russian police staffing shortfall; Vietnam MPS "semi-specialized force" ~2m; Cuba CDR ~8m; North Korea inminban and police. Federal Bureau of Investigation MI5 The Moscow Times Wall Street Journal Wikipedia +2 Wikipedia +2 38 North
+- Comparators: [FBI](https://www.fbi.gov) staffing/budget; [MI5](https://www.mi5.gov.uk) staff; Rosgvardia size & Russian police staffing shortfall; Vietnam MPS "semi-specialized force" ~2m; Cuba CDR ~8m; North Korea inminban and police. [Federal Bureau of Investigation](https://www.fbi.gov) [MI5](https://www.mi5.gov.uk) [The Moscow Times](https://www.themoscowtimes.com) [Wall Street Journal](https://www.wsj.com) [Wikipedia](https://www.wikipedia.org) +2 [Wikipedia](https://www.wikipedia.org) +2 [38 North](https://www.38north.org)


### PR DESCRIPTION
## Summary
- Convert plain-text references in `china_human_monitoring_report.md` to Markdown hyperlinks for easier source navigation.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab46b88500832dbf33083db6a2835e