### PR TITLE
Link MSS intelligence cycle report from related docs

### DIFF
--- a/Grok_MSS_AI_Development_Report.md
+++ b/Grok_MSS_AI_Development_Report.md
@@ -19,4 +19,4 @@ This file summarizes key points from a Grok-provided overview of how China's Min
 - U.S. officials warn that systematic MSS acquisition of AI reduces American technological advantages and enables rapid deployment of low-cost autonomous systems by Chinese firms.
 - Countermeasures include indictments, sanctions, and expanded intelligence sharing, though experts caution that export controls alone may be insufficient.
 - Broader surveillance staffing figures are detailed in [China's Human Monitoring Report](research/china_human_monitoring_report.md), underscoring the domestic scale that supports MSS operations.
-
+- For a detailed analysis of the intelligence cycle, see the [MSS AI Intelligence Cycle Report](research/mss_ai_intelligence_cycle_report.md).

--- a/MSS_AI_Intelligence_1995-2025__ANKAA.md
+++ b/MSS_AI_Intelligence_1995-2025__ANKAA.md
@@ -24,6 +24,7 @@ This article synthesizes open-source research and declassified reporting to outl
 
 ## Implications and Limitations
 China's pursuit of "controllable AI" reflects a balance between technological progress and state security priorities. Open-source evidence indicates robust integration of AI into vulnerability research, surveillance, and military planning. However, many MSS activities remain opaque or unverified. Comparative analysis suggests that while China employs AI aggressively for security purposes, other nations also integrate AI into intelligence, necessitating careful, balanced assessment.
+For up-to-date coverage of MSS practices, see the [MSS AI Intelligence Cycle Report](research/mss_ai_intelligence_cycle_report.md).
 
 ---
 


### PR DESCRIPTION
## Summary
- cross-reference the MSS AI Intelligence Cycle Report from the Grok development summary.
- add same reference to the 1995-2025 MSS AI intelligence overview for up-to-date coverage.

## Testing
- `pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68ab46f501d4832d95407892bcac2f86