### PR TITLE
Add style guide and documentation templates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@
 - Provide a clear summary and list of changes.
 - Cite sources for all factual claims using the format described in `research/`.
 - Engage respectfully during code reviews and address feedback promptly.
+- Follow the [style guide](docs/STYLE.md) for citation format and narrative structure.
 
 ## Working Tree Hygiene
 - Keep your working tree clean: commit related changes and remove generated or temporary files.

--- a/docs/REVIEW_GUIDELINES.md
+++ b/docs/REVIEW_GUIDELINES.md
@@ -1,0 +1,9 @@
+# Review Guidelines
+
+These guidelines help reviewers assess contributions consistently.
+
+1. Confirm the submission follows the [style guide](STYLE.md) for citation format and narrative structure.
+2. Verify that sources are credible and citations include working URLs and access dates.
+3. Check that narratives are organized logically with clear summaries and analysis.
+4. Ensure tests and linters pass before approval.
+5. Provide constructive feedback and document required changes.

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -1,0 +1,18 @@
+# Style Guide
+
+This project uses a consistent citation format and narrative structure to keep reports clear and verifiable.
+
+## Citation Format
+- Use Markdown footnotes or inline links.
+- Provide author, title, publication, and date when available.
+- Include direct URLs and access dates for online sources.
+- Number footnotes sequentially and list them at the end of the document.
+
+## Narrative Structure
+1. **Summary** – one‑paragraph overview of key findings.
+2. **Background** – context on actors, technology, or events.
+3. **Analysis** – evidence, reasoning, and methodology.
+4. **Implications** – why the findings matter.
+5. **Sources** – bibliography or footnotes supporting the narrative.
+
+Follow this structure for case studies, reports, and other analytical documents.

--- a/docs/templates/case-study.md
+++ b/docs/templates/case-study.md
@@ -1,0 +1,20 @@
+# Case Study Title
+
+## Summary
+Provide a brief overview of the operation and its significance.
+
+## Background
+Describe key entities, timelines, and context.
+
+## Key Events
+- Event 1
+- Event 2
+
+## Analysis
+Explain techniques, patterns, and supporting evidence.
+
+## Implications
+Discuss potential impacts or lessons learned.
+
+## Sources
+1. [Source Name](url) – description.

--- a/docs/templates/report.md
+++ b/docs/templates/report.md
@@ -1,0 +1,19 @@
+# Report Title
+
+## Executive Summary
+Summarize key findings and recommended actions.
+
+## Introduction
+Outline the report's scope and objectives.
+
+## Methodology
+Explain data sources and analytical approach.
+
+## Findings
+Detail evidence and results.
+
+## Recommendations
+List actionable steps or future work.
+
+## References
+1. [Source Name](url) – description.


### PR DESCRIPTION
## Summary
- add documentation style guide with citation and narrative rules
- provide markdown templates for case studies and reports
- link style guide from contributing and review guidelines

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab4bfbe430832d89332a0b8c6032b2