### PR TITLE
Add CI configuration and expand dataset test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+source = scripts
+timid = true
+branch = true
+
+[report]
+show_missing = true
+fail_under = 80

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install -r requirements.txt flake8 mypy coverage pytest pytest-cov
+      - run: flake8
+      - run: mypy scripts tests
+      - run: pytest --cov=scripts --cov=tests --cov-report=xml

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+python_version = 3.12
+ignore_missing_imports = true

--- a/tests/test_analyze_datasets.py
+++ b/tests/test_analyze_datasets.py
@@ -1,3 +1,4 @@
+from collections import Counter
 import sys
 from pathlib import Path
 
@@ -45,3 +46,17 @@ def test_analyze_institution_dataset(tmp_path):
 
     summary = format_summary(results)
     assert "InstA: 2" in summary
+
+
+def test_analyze_malformed_header(tmp_path):
+    data_dir = tmp_path / "datasets"
+    data_dir.mkdir()
+    (data_dir / "bad.csv").write_text("id,name\n1,A\n", encoding="utf-8")
+    results = analyze_datasets(data_dir)
+    assert results == [("bad.csv", 0, Counter())]
+
+
+def test_analyze_missing_directory(tmp_path):
+    missing_dir = tmp_path / "missing"
+    results = analyze_datasets(missing_dir)
+    assert results == []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,48 @@
+import csv
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_cli_update_datasets_profile(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    csv_file = tmp_path / "cli.csv"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(repo_root / "scripts/update_datasets.py"),
+            "profile",
+            str(csv_file),
+            "P1",
+            "finance",
+            "src",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=tmp_path,
+    )
+    assert "Appended record for P1" in result.stdout
+    with open(csv_file, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    assert rows == [{"profile_id": "P1", "sector": "finance", "source": "src"}]
+
+
+def test_cli_analyze_datasets(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    data_dir = tmp_path / "datasets"
+    data_dir.mkdir()
+    (data_dir / "a.csv").write_text(
+        "profile_id,sector,source\n1,finance,x\n", encoding="utf-8"
+    )
+    result = subprocess.run(
+        [sys.executable, str(repo_root / "scripts/analyze_datasets.py")],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=tmp_path,
+    )
+    assert "Wrote summary" in result.stdout
+    summary_file = data_dir / "analysis_summary.md"
+    content = summary_file.read_text(encoding="utf-8")
+    assert "Total records: 1" in content

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,26 @@
+import csv
+import threading
+
+from scripts.update_datasets import append_record
+
+
+def test_concurrent_appends_same_id(tmp_path):
+    csv_file = tmp_path / "data.csv"
+    errors = []
+
+    def worker():
+        try:
+            append_record(csv_file, "P1", "finance", "src")
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    with open(csv_file, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    assert len(rows) == 1
+    assert any(isinstance(e, ValueError) for e in errors)

--- a/tests/test_update_datasets.py
+++ b/tests/test_update_datasets.py
@@ -114,3 +114,28 @@ def test_append_partnership_empty_fields(
     csv_file = tmp_path / "mcf.csv"
     with pytest.raises(ValueError):
         append_partnership(csv_file, institution, partner, partnership_type, source)
+
+
+def test_append_record_creates_file_when_missing(tmp_path):
+    csv_file = tmp_path / "data.csv"
+    append_record(csv_file, "P1", "finance", "src")
+    assert csv_file.exists()
+    with open(csv_file, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    assert rows == [{"profile_id": "P1", "sector": "finance", "source": "src"}]
+
+
+def test_append_record_malformed_header(tmp_path):
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_text("profile,sector,source\nP1,finance,src\n", encoding="utf-8")
+    with pytest.raises(KeyError):
+        append_record(csv_file, "P1", "finance", "src")
+
+
+def test_append_partnership_case_sensitive_duplicate(tmp_path):
+    csv_file = tmp_path / "mcf.csv"
+    append_partnership(csv_file, "InstA", "Partner1", "research", "osint")
+    append_partnership(csv_file, "insta", "partner1", "research", "osint")
+    with open(csv_file, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    assert len(rows) == 2


### PR DESCRIPTION
## Summary
- add flake8, mypy, and coverage configuration files
- create GitHub Actions workflow for linting, type checking, testing, and coverage
- expand tests for malformed CSVs, CLI usage, concurrency, and duplicate edge cases

## Testing
- `flake8` *(fails: command not found)*
- `mypy --explicit-package-bases scripts tests`
- `pytest --cov=scripts --cov=tests` *(fails: unrecognized arguments)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab4bfd6f34832db7d547f4b8ffe25f