### PR TITLE
docs: add code of conduct, citation file, and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,14 @@
+# Issue Template
+
+## Summary
+Provide a clear and concise description of the issue or new evidence.
+
+## Evidence
+- Attach supporting files or links.
+- Cite all sources using the repository's citation style.
+
+## Proposed Actions
+Outline potential steps or research paths to resolve the issue.
+
+## Additional Context
+Add any other context, references, or citations.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+# Pull Request Template
+
+## Summary
+Explain the purpose of this pull request and the changes introduced.
+
+## Related Issues
+Reference any related issues or discussions.
+
+## Evidence and Citations
+- List evidence supporting your changes.
+- Cite sources using the repository's citation style.
+
+## Testing
+- [ ] `pytest`
+- [ ] Other checks as applicable
+
+## Additional Notes
+Include any additional context or follow-up questions.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,15 @@
+cff-version: 1.2.0
+message: "If you use this project, please cite it as below."
+title: "MSS LinkedIn Infiltration Investigation"
+authors:
+  - family-names: "Research Team"
+    given-names: "SWED-AI"
+repository-code: "https://github.com/unknown/SWED-AI-RQIE-O-HI-E-H"
+preferred-citation:
+  type: article
+  title: "MSS LinkedIn Infiltration Investigation"
+  authors:
+    - family-names: "Research Team"
+      given-names: "SWED-AI"
+  year: 2024
+  url: "https://github.com/unknown/SWED-AI-RQIE-O-HI-E-H"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,66 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+We as members, contributors, and leaders pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at <https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,12 @@
 ## Commit Messages
 - Write descriptive commit messages that explain the intent of the change.
 - Reference issues or relevant discussions when applicable.
+- Use concise prefixes such as `docs:`, `research:`, or `feat:` followed by a short summary.
+
+### Examples
+- `docs: add code of conduct`
+- `research: update shell company dossier`
+- `feat: automate dataset analysis`
 
 ## Pull Requests
 - Ensure your branch is up to date with `main` before opening a pull request.
@@ -21,3 +27,8 @@
 ## Research Guidelines
 - Follow the project research guidelines located in the `research/` directory.
 - Reference these guidelines when contributing new analyses or data.
+
+### Exemplary Contributions
+- Annotated datasets linking persona accounts to infrastructure nodes.
+- Comparative analysis of outreach scripts across regions.
+- Reproductions of existing methodologies on new case data.


### PR DESCRIPTION
## Summary
- add Contributor Covenant code of conduct
- provide CITATION.cff with project metadata
- expand contributing guide and add issue/PR templates stressing evidence and citations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab4bf58448832db7f5a50632eab90e